### PR TITLE
Reconnect v2

### DIFF
--- a/kube.yml
+++ b/kube.yml
@@ -126,7 +126,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: arejula27/kvs:v1.1 # Replace with your actual image
+          image: dnagard/kv_store:v2.4 # Replace with your actual image
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v4.1
+          image: dnagard/kv_store:v4.8
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -1,3 +1,6 @@
+# -------------------------------
+# ConfigMap for Configuration
+# -------------------------------
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,7 +8,34 @@ metadata:
 data:
   NODES: "[1, 2, 3]"
   RUST_BACKTRACE: "1"
+
 ---
+# -------------------------------
+# Headless Service for StatefulSet Networking
+# -------------------------------
+apiVersion: v1
+kind: Service
+metadata:
+  name: kv-store
+spec:
+  clusterIP: None  # Headless service for StatefulSet DNS resolution
+  selector:
+    app: kv-store
+  ports:
+    - port: 8001
+      targetPort: 8001
+      name: "8001"
+    - port: 8002
+      targetPort: 8002
+      name: "8002"
+    - port: 8003
+      targetPort: 8003
+      name: "8003"
+
+---
+# -------------------------------
+# Headless Service for Networking (Net)
+# -------------------------------
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,9 +43,9 @@ metadata:
   labels:
     app: net
 spec:
-  clusterIP: None  # Headless service, no single IP
+  clusterIP: None
   selector:
-    app: net  # This selector needs to match the label of the 'net' pod
+    app: net
   ports:
     - name: "8001"
       port: 8001
@@ -67,6 +97,9 @@ spec:
       name: "8042"
 
 ---
+# -------------------------------
+# Single Pod for Networking (Net)
+# -------------------------------
 apiVersion: v1
 kind: Pod
 metadata:
@@ -91,13 +124,12 @@ spec:
         - containerPort: 8021
         - containerPort: 8032
         - containerPort: 8031
-
       env:
         - name: PORT_MAPPINGS
           value: "[[8013,8031],[8012,8021],[8023,8032], [8014, 8041], [8024, 8042], [8034, 8043]]"
         - name: CLIENT_PORTS
           value: "[8001, 8002, 8003, 8004]"
-        - name: NODES  
+        - name: NODES
           valueFrom:
             configMapKeyRef:
               name: kv-config
@@ -107,8 +139,11 @@ spec:
             configMapKeyRef:
               name: kv-config
               key: RUST_BACKTRACE
----
 
+---
+# -------------------------------
+# StatefulSet for Distributed Database (With Persistent Storage)
+# -------------------------------
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -126,7 +161,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v2.4 # Replace with your actual image
+          image: dnagard/kv_store:v4.1
           imagePullPolicy: Always
           env:
             - name: NODES
@@ -144,5 +179,21 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
-          # As the program does not allow to have PID=0, we need to increment the PID by 1
-          args: ["export PID=$(echo $POD_NAME | sed 's/[^0-9]*\\([0-9]*\\)$/\\1/')&& PID=$((PID + 1)) && exec kv_demo"]
+          args:
+            [
+              "export PID=$(echo $POD_NAME | sed 's/[^0-9]*\\([0-9]*\\)$/\\1/')&& PID=$((PID + 1))
+              && exec kv_demo",
+            ]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: standard  # Explicitly defined for clarity

--- a/kube.yml
+++ b/kube.yml
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: batuy/kv_store:v1.1
+          image: dnagard/kv_store:v5.0
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -11,29 +11,6 @@ data:
 
 ---
 # -------------------------------
-# Headless Service for StatefulSet Networking
-# -------------------------------
-apiVersion: v1
-kind: Service
-metadata:
-  name: kv-store
-spec:
-  clusterIP: None  # Headless service for StatefulSet DNS resolution
-  selector:
-    app: kv-store
-  ports:
-    - port: 8001
-      targetPort: 8001
-      name: "8001"
-    - port: 8002
-      targetPort: 8002
-      name: "8002"
-    - port: 8003
-      targetPort: 8003
-      name: "8003"
-
----
-# -------------------------------
 # Headless Service for Networking (Net)
 # -------------------------------
 apiVersion: v1
@@ -109,7 +86,7 @@ metadata:
 spec:
   containers:
     - name: net
-      image: arejula27/kvs-network-actor:v1.3
+      image: dnagard/net_actor:v1.4
       imagePullPolicy: Always
       stdin: true
       tty: true
@@ -161,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v4.8
+          image: dnagard/kv_store:v5.0
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -86,7 +86,7 @@ metadata:
 spec:
   containers:
     - name: net
-      image: dnagard/net_actor:v1.4
+      image: dnagard/net_actor:v1.6
       imagePullPolicy: Always
       stdin: true
       tty: true
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v5.0
+          image: batuy/kv_store:v1.1
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kv_store/src/main.rs
+++ b/kv_store/src/main.rs
@@ -1,7 +1,8 @@
 use crate::kv::KVCommand;
 use crate::server::Server;
 use omnipaxos::*;
-use omnipaxos_storage::memory_storage::MemoryStorage;
+use omnipaxos_storage::persistent_storage::{PersistentStorage, PersistentStorageConfig};
+use rocksdb;
 use std::env;
 use tokio;
 
@@ -31,7 +32,7 @@ lazy_static! {
     };
 }
 
-type OmniPaxosKV = OmniPaxos<KVCommand, MemoryStorage<KVCommand>>;
+type OmniPaxosKV = OmniPaxos<KVCommand, PersistentStorage<KVCommand>>;
 
 #[tokio::main]
 async fn main() {
@@ -49,13 +50,36 @@ async fn main() {
         server_config,
         cluster_config,
     };
+    
+    // Set storage path for this node (each pod gets its own)
+    let storage_path = format!("/data/omnipaxos_{}", *PID);
+    std::fs::create_dir_all(&storage_path).expect("Failed to create storage directory");
+    
+    // Set RocksDB options (required for persistent storage)
+    let log_store_options = rocksdb::Options::default();
+    let mut state_store_options = rocksdb::Options::default();
+    state_store_options.create_missing_column_families(true); // Ensures required storage structure
+    state_store_options.create_if_missing(true); // Creates DB if missing
+    
+    // Create persistent storage config with options
+    let mut persist_conf = PersistentStorageConfig::default();
+    persist_conf.set_path(storage_path.to_string()); 
+    persist_conf.set_database_options(state_store_options);
+    persist_conf.set_log_options(log_store_options);
+    
+    // Initialize storage using PersistentStorageConfig (Fix: Proper error handling)
+    let storage = PersistentStorage::open(persist_conf);
+
+    // Recover OmniPaxos state from storage
     let omni_paxos = op_config
-        .build(MemoryStorage::default())
-        .expect("failed to build OmniPaxos");
+        .build(storage)
+        .expect("Failed to build OmniPaxos");
+    
+    // Ensure database storage also uses /data/
     let mut server = Server {
         omni_paxos,
         network: network::Network::new().await,
-        database: database::Database::new(format!("db_{}", *PID).as_str()),
+        database: database::Database::new(format!("/data/db_{}", *PID).as_str()),
         last_decided_idx: 0,
     };
     server.run().await;

--- a/kv_store/src/network.rs
+++ b/kv_store/src/network.rs
@@ -1,10 +1,9 @@
-// This file defines a networking module for a distributed key-value store that uses OmniPaxos for consensus. It provides the mechanisms for sending and receiving messages between nodes and clients, as well as processing incoming messages and sending outgoing messages. The Network struct manages the connections to other nodes and clients, while the Message enum defines the types of messages that can be sent and received.
-
 use omnipaxos::messages::Message as OPMessage;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::{tcp, TcpStream},
@@ -13,67 +12,49 @@ use tokio::{
 
 use crate::{kv::KVCommand, server::APIResponse, NODES, PID as MY_PID};
 
-// Represents the types of messages that can be sent and received.
-// Derives Serialize and Deserialize (via serde) to allow for serialization and deserialization of the enum variants.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum Message {
     OmniPaxosMsg(OPMessage<KVCommand>), 
-    APIRequest(KVCommand), //Represents a request from a client to the server
-    APIResponse(APIResponse), //Represents a response from the server to a client
+    APIRequest(KVCommand),
+    APIResponse(APIResponse),
+    Debug(String),
 }
 
-//Defining the Network struct
 pub struct Network {
-    //Maps peer IDs to the write-half of their TCP connections.
-    sockets: HashMap<u64, tcp::OwnedWriteHalf>, 
-    //An optional write-half for teh connection to the API client (using receiver ID 0).
-    api_socket: Option<tcp::OwnedWriteHalf>,
-    //A shared, thread-safe (wrapped in Arc<Mutex<...>>) buffer for storing incoming messages until they are processed.
+    // Wrap sockets in an Arc<Mutex<...>> for concurrent access and updates.
+    sockets: Arc<Mutex<HashMap<u64, tcp::OwnedWriteHalf>>>,
+    // Wrap the API socket in a Mutex to allow mutable access when writing.
+    api_socket: Arc<Mutex<Option<tcp::OwnedWriteHalf>>>,
     incoming_msg_buf: Arc<Mutex<Vec<Message>>>,
 }
 
-// Implementing the Network struct
 impl Network {
-
-    //Constructs the address for the API connection based on the node's PID
-    //Used to connect to the API clinet for sending or receiving messages. 
-    // {} is replaced by the dereferenced PID value.
     fn get_my_api_addr() -> String {
         format!("net.default.svc.cluster.local:800{}", *MY_PID)
     }
 
-    //Generates the address for a peer connection based on the current nodes PID and the receiver's PID.
-    //Used to connect to other nodes for sending or receiving messages.
-    // {}{} is replaced by the current node's PID and the receiver's PID.
     fn get_peer_addr(receiver_pid: u64) -> String {
-        format!(
-            "net.default.svc.cluster.local:80{}{}",
-            *MY_PID, receiver_pid
-        )
+        format!("net.default.svc.cluster.local:80{}{}", *MY_PID, receiver_pid)
     }
 
-    /// Sends a serialized JSON message over the appropriate TCP connection
-    /// u64 0 is the Client.
-    pub(crate) async fn send(&mut self, receiver: u64, msg: Message) {
-        //If the receiver is 0, send the message over teh api_socket; 
-        // otherwise retrieve the corresponding peer socket from the sockets hashmap.
-        // This if statement is treated as a RHV (right-hand value) expression, setting the writer variable to the appropriate connection.
-        let writer = if receiver == 0 {
-            self.api_socket.as_mut()
+    /// Sends a serialized JSON message over the appropriate TCP connection.
+    pub(crate) async fn send(&self, receiver: u64, msg: Message) {
+        let mut data = serde_json::to_vec(&msg).expect("could not serialize msg");
+        data.push(b'\n');
+        if receiver == 0 {
+            let mut api_lock = self.api_socket.lock().await;
+            if let Some(writer) = api_lock.as_mut() {
+                let _ = writer.write_all(&data).await;
+            }
         } else {
-            self.sockets.get_mut(&receiver)
-        };
-
-        //Some(writer) = writer is a pattern to check if a writer exists. If writer is 'Some', a valid socket exists => execute the block
-        if let Some(writer) = writer {
-            let mut data = serde_json::to_vec(&msg).expect("could not serialize msg");
-            data.push(b'\n');
-            writer.write_all(&data).await.unwrap(); //Write the serialized message to the socket. Await waits for the write to complete. Unwrap panics if the write fails.
+            let mut sockets_lock = self.sockets.lock().await;
+            if let Some(writer) = sockets_lock.get_mut(&receiver) {
+                let _ = writer.write_all(&data).await;
+            }
         }
     }
 
     /// Returns all messages received since last called.
-    // Locks the shared message buffer, clones its contentens to return, and clears the buffer, releasing the lock (when it goes out of scope).
     pub(crate) async fn get_received(&mut self) -> Vec<Message> {
         let mut buf = self.incoming_msg_buf.lock().await;
         let ret = buf.to_vec();
@@ -81,18 +62,7 @@ impl Network {
         ret
     }
 
-    /* 
-    Sets up all the necessary connections and asynchronous tasks required for the network layer to operate. 
-    Returns an initialized Network instance ready to send and receive messages. 
-    -----------------------------------------------------------
-    * Peer discovery: Creates a list of peer PIDs by filtering the NODES list to exclude the current node's PID.
-    * Connecting to the API: Constructs the API address using get_my_api_addr() and connects to it using TCP. Splits the connection into a reader and writer, storing the writer in api_socket.
-    * Shared message buffer: Creates a shared, thread-safe buffer for storing incoming messages across multiple async tasks.
-    * Spawning reader tasks:
-        *API reader task: A Tokio task is spawend that continously reads from the API connection using a buffered reader. Every timea  complete message (ending in a newline) is received, it is deserialied and appended to teh sahred message buffer.
-        * Peer reader task: For each peer, a similar task is spawned to read incoming messages from that peer's TCP connection. These messages are alsod eserialized and appended to the shared message buffer.
-    *Storing Peer Writers: The writer half of each TCP connection is stored int he sockets HashMap so that messages can be sent to those peers later.  
-    */
+    /// Constructs and initializes the Network instance.
     pub(crate) async fn new() -> Self {
         let peers: Vec<u64> = NODES
             .iter()
@@ -109,49 +79,88 @@ impl Network {
             .await
             .expect(&err_msg);
         let (api_reader, api_writer) = api_stream.into_split();
-        let api_socket = Some(api_writer);
+        let api_socket = Arc::new(Mutex::new(Some(api_writer)));
         let incoming_msg_buf = Arc::new(Mutex::new(vec![]));
-        let msg_buf = incoming_msg_buf.clone();
-        tokio::spawn(async move {
-            let mut reader = BufReader::new(api_reader);
-            let mut data = Vec::new();
-            loop {
-                data.clear();
-                let bytes_read = reader.read_until(b'\n', &mut data).await;
-                if bytes_read.is_err() {
-                    // stream ended?
-                    panic!("stream ended?")
-                }
-                let msg: Message =
-                    serde_json::from_slice(&data).expect("could not deserialize msg");
-                msg_buf.lock().await.push(msg);
-            }
-        });
 
-        let mut sockets = HashMap::new();
-        for peer in &peers {
-            let addr = peer_addrs.get(&peer).unwrap().clone();
-            println!("Connecting to {}", addr);
-            let stream = TcpStream::connect(addr).await.unwrap();
-            let (reader, writer) = stream.into_split();
-            sockets.insert(*peer, writer);
+        // Spawn a task to continuously read from the API connection.
+        {
             let msg_buf = incoming_msg_buf.clone();
             tokio::spawn(async move {
-                let mut reader = BufReader::new(reader);
+                let mut reader = BufReader::new(api_reader);
                 let mut data = Vec::new();
                 loop {
                     data.clear();
-                    let bytes_read = reader.read_until(b'\n', &mut data).await;
-                    if bytes_read.is_err() {
-                        // stream ended?
-                        panic!("stream ended?")
+                    match reader.read_until(b'\n', &mut data).await {
+                        Ok(0) => {
+                            println!("API connection closed. (Reconnection not implemented here.)");
+                            break;
+                        }
+                        Ok(_) => {
+                            let msg: Message =
+                                serde_json::from_slice(&data).expect("could not deserialize msg");
+                            msg_buf.lock().await.push(msg);
+                        }
+                        Err(e) => {
+                            println!("Error reading from API: {}. Retrying...", e);
+                            break;
+                        }
                     }
-                    let msg: Message =
-                        serde_json::from_slice(&data).expect("could not deserialize msg");
-                    msg_buf.lock().await.push(msg);
                 }
             });
         }
+
+        let sockets = Arc::new(Mutex::new(HashMap::new()));
+
+        // For each peer, spawn a task that continuously attempts to connect and read messages.
+        for peer in peers {
+            let addr = peer_addrs.get(&peer).unwrap().clone();
+            let sockets_clone = sockets.clone();
+            let msg_buf = incoming_msg_buf.clone();
+            tokio::spawn(async move {
+                loop {
+                    println!("Attempting connection to peer {} at {}", peer, addr);
+                    match TcpStream::connect(&addr).await {
+                        Ok(stream) => {
+                            println!("Connected to peer {} at {}", peer, addr);
+                            let (reader, writer) = stream.into_split();
+                            // Update the sockets map with the new writer.
+                            sockets_clone.lock().await.insert(peer, writer);
+                            let mut reader = BufReader::new(reader);
+                            let mut data = Vec::new();
+                            loop {
+                                data.clear();
+                                match reader.read_until(b'\n', &mut data).await {
+                                    Ok(0) => {
+                                        println!("Connection closed by peer {}", peer);
+                                        break;
+                                    }
+                                    Ok(_) => {
+                                        let msg: Message = serde_json::from_slice(&data)
+                                            .expect("could not deserialize msg");
+                                        msg_buf.lock().await.push(msg);
+                                    }
+                                    Err(e) => {
+                                        println!(
+                                            "Error reading from peer {}: {}. Retrying connection...",
+                                            peer, e
+                                        );
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            println!(
+                                "Failed to connect to peer {} at {}: {}. Retrying...",
+                                peer, addr, e
+                            );
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            });
+        }
+
         Self {
             sockets,
             api_socket,

--- a/kv_store/src/network.rs
+++ b/kv_store/src/network.rs
@@ -50,6 +50,8 @@ impl Network {
             let mut sockets_lock = self.sockets.lock().await;
             if let Some(writer) = sockets_lock.get_mut(&receiver) {
                 let _ = writer.write_all(&data).await;
+            } else {
+                println!("Warning: No connection to peer {}, message not sent", receiver);
             }
         }
     }
@@ -132,6 +134,7 @@ impl Network {
                                 match reader.read_until(b'\n', &mut data).await {
                                     Ok(0) => {
                                         println!("Connection closed by peer {}", peer);
+                                        sockets_clone.lock().await.remove(&peer);
                                         break;
                                     }
                                     Ok(_) => {
@@ -144,6 +147,7 @@ impl Network {
                                             "Error reading from peer {}: {}. Retrying connection...",
                                             peer, e
                                         );
+                                        sockets_clone.lock().await.remove(&peer);
                                         break;
                                     }
                                 }

--- a/kv_store/src/server.rs
+++ b/kv_store/src/server.rs
@@ -6,6 +6,7 @@ use crate::kv::KVCommand;
 use crate::{
     network::{Message, Network},
     OmniPaxosKV,
+    PID as MY_PID,
 };
 use omnipaxos::util::LogEntry;
 use serde::{Deserialize, Serialize};
@@ -50,7 +51,10 @@ impl Server {
                 },
                 Message::OmniPaxosMsg(msg) => {
                     self.omni_paxos.handle_incoming(msg);
-                }
+                }, 
+                Message::Debug(msg) => {
+                    println!("Debug: {}", msg);
+                },
                 _ => unimplemented!(),
             }
         }
@@ -111,12 +115,21 @@ impl Server {
         }
     }
 
+    async fn debug_heartbeat(&mut self) {
+        //Send a debug message to nodes 1, 2, and 3 saying "Heartbeat from node <MY_PID>"
+        for pid in 1..4 {
+            let msg = Message::Debug(format!("Heartbeat from node {}", *MY_PID));
+            self.network.send(pid, msg).await;
+        }
+    }
+
     //Main loop of the server that processes incoming messages, sends outgoing messages, and updates the database based on decided entries.
     //The run method uses tokio::select! to handle multiple asynchronous tasks concurrently.
     //The biased; directive gives priority to the first branch (message processing).
     pub(crate) async fn run(&mut self) {
         let mut msg_interval = time::interval(Duration::from_millis(1));
         let mut tick_interval = time::interval(Duration::from_millis(10));
+        let mut debug_heartbeat = time::interval(Duration::from_secs(5));
         loop {
             tokio::select! {
                 biased;
@@ -127,6 +140,9 @@ impl Server {
                 },
                 _ = tick_interval.tick() => {
                     self.omni_paxos.tick();
+                },
+                _ = debug_heartbeat.tick() => {
+                    self.debug_heartbeat().await;
                 },
                 else => (),
             }

--- a/kv_store/src/server.rs
+++ b/kv_store/src/server.rs
@@ -6,6 +6,7 @@ use crate::kv::KVCommand;
 use crate::{
     network::{Message, Network},
     OmniPaxosKV,
+    NODES,
     PID as MY_PID,
 };
 use omnipaxos::util::LogEntry;
@@ -117,7 +118,12 @@ impl Server {
 
     async fn debug_heartbeat(&mut self) {
         //Send a debug message to nodes 1, 2, and 3 saying "Heartbeat from node <MY_PID>"
-        for pid in 1..4 {
+        let peers: Vec<u64> = NODES
+            .iter()
+            .filter(|pid| **pid != *MY_PID)
+            .cloned()
+            .collect();
+        for pid in peers {
             let msg = Message::Debug(format!("Heartbeat from node {}", *MY_PID));
             self.network.send(pid, msg).await;
         }
@@ -129,7 +135,7 @@ impl Server {
     pub(crate) async fn run(&mut self) {
         let mut msg_interval = time::interval(Duration::from_millis(1));
         let mut tick_interval = time::interval(Duration::from_millis(10));
-        let mut debug_heartbeat = time::interval(Duration::from_secs(5));
+        let mut debug_heartbeat = time::interval(Duration::from_secs(2));
         loop {
             tokio::select! {
                 biased;

--- a/network_actor/src/network.rs
+++ b/network_actor/src/network.rs
@@ -106,7 +106,6 @@ pub async fn run() {
     let partitions: Arc<Mutex<Vec<(u64, u64, f32)>>> = Arc::new(Mutex::new(vec![]));
     let mut out_channels = HashMap::new();
     for port in PORT_MAPPINGS.keys() {
-        // ! Since we create one sender per port in the port mappings, we may want to create a new sender when the old port is broken (because of a pod crash)
         let (sender, _rec) = broadcast::channel::<Vec<u8>>(10000);
         let sender = Arc::new(sender);
         out_channels.insert(*port, sender.clone());
@@ -130,8 +129,7 @@ pub async fn run() {
                             .unwrap();
                         let (socket, _addr) = listener.accept().await.unwrap();
                         let (reader, mut writer) = socket.into_split();
-                        //! Added debug print statement here to see new connections
-                        println!("New connection on port {}", port);
+                        println!("Connected to port {}", port);
 
                         // Sender actor
                         let out_channels = out_chans.clone();
@@ -140,10 +138,8 @@ pub async fn run() {
                                 let mut receiver = sender.clone().subscribe();
                                 while let Ok(data) = receiver.recv().await {
                                     let _ = writer.write_all(&data).await;
-                                    // TODO: Should probably handle dropped writer here. This is the link that is probably broken
                                 }
-                                // TODO: Handle dropped sender. How?
-                                // ? Remove from out channels? Drop the reciever subscription?
+                                println!("Disconnected from port {} (sender actor)", port);
                             }
                         });
 
@@ -158,14 +154,11 @@ pub async fn run() {
                                         if let Err(_e) =
                                             central_sender.send((port, *mapped_port, data)).await
                                         {
-                                            // ? What does this error check for?
                                             break;
                                         }
                                     }
                                 } else {
-                                    // ! Handled dropped connections by removing them from outchans
-                                    println!("Connection on port {} dropped, removing from out_channels", port);
-                                    ///out_channels.lock().await.remove(&port);
+                                    println!("Disconnected from port {} (receiver actor)", port);
                                     break;
                                 }
                             }


### PR DESCRIPTION
Added preliminary persistent storage, to be modified later. 

Edited network actor to ensure more robust TCP connection handling. Makes the reconnection between pods in the stateful set seamless. It is handled almost entirely by the network actor multiplexer now. 