### PR TITLE
Snapshot recovery functionality fully implemented

### DIFF
--- a/kube.yml
+++ b/kube.yml
@@ -86,7 +86,7 @@ metadata:
 spec:
   containers:
     - name: net
-      image: dnagard/net_actor:v1.6
+      image: dnagard/net_actor:v2.0
       imagePullPolicy: Always
       stdin: true
       tty: true
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v5.0
+          image: dnagard/kv_store:v6.10
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -86,7 +86,7 @@ metadata:
 spec:
   containers:
     - name: net
-      image: dnagard/net_actor:v2.0
+      image: dnagard/net_actor:v1.6
       imagePullPolicy: Always
       stdin: true
       tty: true
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v6.10
+          image: dnagard/kv_store:v7.0
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -86,7 +86,7 @@ metadata:
 spec:
   containers:
     - name: net
-      image: dnagard/net_actor:v1.6
+      image: dnagard/net_actor:v2.0
       imagePullPolicy: Always
       stdin: true
       tty: true
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v7.0
+          image: dnagard/kv_store:v7.4
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kv_store/src/database.rs
+++ b/kv_store/src/database.rs
@@ -1,4 +1,4 @@
-use crate::kv::{KVCommand, KeyValue};
+use crate::kv::{KVCommand, KeyValue, KVSnapshot};
 use rocksdb::{Options, DB};
 
 pub struct Database {
@@ -11,6 +11,16 @@ impl Database {
         opts.create_if_missing(true);
         let rocks_db = DB::open(&opts, path).unwrap();
         Self { rocks_db }
+    }
+
+    pub fn handle_snapshot(&self, snapshot: KVSnapshot) {
+        println!("Handling snapshot");
+        for (key, value) in snapshot.snapshotted {
+            self.put(&key, &value);
+        }
+        for key in snapshot.deleted_keys {
+            self.delete(&key);
+        }
     }
 
     pub fn handle_command(&self, command: KVCommand) -> Option<String> {

--- a/kv_store/src/kv.rs
+++ b/kv_store/src/kv.rs
@@ -21,8 +21,8 @@ impl Entry for KVCommand {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KVSnapshot {
-    snapshotted: HashMap<String, String>,
-    deleted_keys: Vec<String>,
+    pub snapshotted: HashMap<String, String>,
+    pub deleted_keys: Vec<String>,
 }
 
 impl Snapshot<KVCommand> for KVSnapshot {
@@ -33,18 +33,24 @@ impl Snapshot<KVCommand> for KVSnapshot {
             match e {
                 KVCommand::Put(KeyValue { key, value }) => {
                     snapshotted.insert(key.clone(), value.clone());
+                    println!("Put key: {}, value: {}", key, value);
                 }
                 KVCommand::Delete(key) => {
                     if snapshotted.remove(key).is_none() {
                         // key was not in the snapshot
+                        println!("Not in snapshot key: {}", key);
                         deleted_keys.push(key.clone());
                     }
+                    deleted_keys.push(key.clone());
                 }
                 KVCommand::Get(_) => (),
             }
         }
         // remove keys that were put back
         deleted_keys.retain(|k| !snapshotted.contains_key(k));
+        println!("Deleted keys: {:?}", deleted_keys);
+        println!("Snapshotted: {:?}", snapshotted);
+
         Self {
             snapshotted,
             deleted_keys,
@@ -52,13 +58,18 @@ impl Snapshot<KVCommand> for KVSnapshot {
     }
 
     fn merge(&mut self, delta: Self) {
+        println!("Merging snapshot");
+        println!("Delta snapshot: {:?}", delta.snapshotted);
+        println!("Delta deleted keys: {:?}", delta.deleted_keys);
+        println!("Current snapshot: {:?}", self.snapshotted);
+        println!("Current deleted keys: {:?}", self.deleted_keys);
         for (k, v) in delta.snapshotted {
             self.snapshotted.insert(k, v);
         }
         for k in delta.deleted_keys {
             self.snapshotted.remove(&k);
         }
-        self.deleted_keys.clear();
+        //self.deleted_keys.retain(|k| !self.snapshotted.contains_key(k));
     }
 
     fn use_snapshots() -> bool {

--- a/kv_store/src/kv.rs
+++ b/kv_store/src/kv.rs
@@ -68,6 +68,7 @@ impl Snapshot<KVCommand> for KVSnapshot {
         }
         for k in delta.deleted_keys {
             self.snapshotted.remove(&k);
+            self.deleted_keys.push(k);
         }
         //self.deleted_keys.retain(|k| !self.snapshotted.contains_key(k));
     }

--- a/kv_store/src/kv.rs
+++ b/kv_store/src/kv.rs
@@ -70,7 +70,7 @@ impl Snapshot<KVCommand> for KVSnapshot {
             self.snapshotted.remove(&k);
             self.deleted_keys.push(k);
         }
-        //self.deleted_keys.retain(|k| !self.snapshotted.contains_key(k));
+        self.deleted_keys.retain(|k| !self.snapshotted.contains_key(k));
     }
 
     fn use_snapshots() -> bool {

--- a/kv_store/src/network.rs
+++ b/kv_store/src/network.rs
@@ -18,6 +18,7 @@ pub(crate) enum Message {
     APIRequest(KVCommand),
     APIResponse(APIResponse),
     Debug(String),
+    Reconnect(u64),
 }
 
 pub struct Network {

--- a/kv_store/src/server.rs
+++ b/kv_store/src/server.rs
@@ -103,19 +103,19 @@ impl Server {
             let msg = Message::APIResponse(APIResponse::Decided(new_decided_idx as u64));
             self.network.send(0, msg).await;
             // snapshotting
-            // if new_decided_idx % 5 == 0 {
-            //     println!(
-            //         "Log before: {:?}",
-            //         self.omni_paxos.read_decided_suffix(0).unwrap()
-            //     );
-            //     self.omni_paxos
-            //         .snapshot(Some(new_decided_idx), true)
-            //         .expect("Failed to snapshot");
-            //     println!(
-            //         "Log after: {:?}\n",
-            //         self.omni_paxos.read_decided_suffix(0).unwrap()
-            //     );
-            // }
+            if new_decided_idx % 5 == 0 {
+                println!(
+                    "Log before: {:?}",
+                    self.omni_paxos.read_decided_suffix(0).unwrap()
+                );
+                self.omni_paxos
+                    .snapshot(Some(new_decided_idx), true)
+                    .expect("Failed to snapshot");
+                println!(
+                    "Log after: {:?}\n",
+                    self.omni_paxos.read_decided_suffix(0).unwrap()
+                );
+            }
         }
     }
 
@@ -154,8 +154,12 @@ impl Server {
         let file_path = "data/restarted.flag";
 
         if Path::new(file_path).exists() {
+            let own_decided_index = self.omni_paxos.get_decided_idx();
+            self.omni_paxos
+                    .snapshot(Some(own_decided_index), true)
+                    .expect("Failed to snapshot");
             println!("Restarted");
-            std::thread::sleep(Duration::from_secs(5));
+            std::thread::sleep(Duration::from_secs(3));
             println!("After sleep");
             for pid in NODES.iter().filter(|pid| **pid != *MY_PID) {
                 //self.omni_paxos.seq_paxos.state = {Follower, Recover};

--- a/kv_store/src/server.rs
+++ b/kv_store/src/server.rs
@@ -103,19 +103,19 @@ impl Server {
             let msg = Message::APIResponse(APIResponse::Decided(new_decided_idx as u64));
             self.network.send(0, msg).await;
             // snapshotting
-            if new_decided_idx % 5 == 0 {
-                println!(
-                    "Log before: {:?}",
-                    self.omni_paxos.read_decided_suffix(0).unwrap()
-                );
-                self.omni_paxos
-                    .snapshot(Some(new_decided_idx), true)
-                    .expect("Failed to snapshot");
-                println!(
-                    "Log after: {:?}\n",
-                    self.omni_paxos.read_decided_suffix(0).unwrap()
-                );
-            }
+            // if new_decided_idx % 5 == 0 {
+            //     println!(
+            //         "Log before: {:?}",
+            //         self.omni_paxos.read_decided_suffix(0).unwrap()
+            //     );
+            //     self.omni_paxos
+            //         .snapshot(Some(new_decided_idx), true)
+            //         .expect("Failed to snapshot");
+            //     println!(
+            //         "Log after: {:?}\n",
+            //         self.omni_paxos.read_decided_suffix(0).unwrap()
+            //     );
+            // }
         }
     }
 


### PR DESCRIPTION
Added logic to ensure that if a node was down for a brief second while a command was decided on, this decision was later broadcast to the reconnected node. This originally worked only for put commands, but this pull request ensures that it also works for delete commands.

The issue was mainly in how snapshots were created and handled in the kv.rs file.