### PR TITLE
Scaling pods - Functional Implementation

### DIFF
--- a/kube.yml
+++ b/kube.yml
@@ -6,7 +6,7 @@ kind: ConfigMap
 metadata:
   name: kv-config
 data:
-  NODES: "[1, 2, 3]"
+  NODES: "[1, 2, 3, 4]"
   RUST_BACKTRACE: "1"
 
 ---
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v7.4
+          image: dnagard/kv_store:v7.5
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kube.yml
+++ b/kube.yml
@@ -1,4 +1,33 @@
 # -------------------------------
+# RBAC Configuration for StatefulSets Access
+# -------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: statefulset-reader
+  namespace: default
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: statefulset-reader-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: Role
+  name: statefulset-reader
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# -------------------------------
 # ConfigMap for Configuration
 # -------------------------------
 apiVersion: v1
@@ -27,51 +56,51 @@ spec:
     - name: "8001"
       port: 8001
       targetPort: 8001
-    - port: 8002
+    - name: "8002"
+      port: 8002
       targetPort: 8002
-      name: "8002"
-    - port: 8003
-      name: "8003"
+    - name: "8003"
+      port: 8003
       targetPort: 8003
-    - port: 8004
+    - name: "8004"
+      port: 8004
       targetPort: 8004
-      name: "8004"
-    - port: 8013
+    - name: "8013"
+      port: 8013
       targetPort: 8013
-      name: "8013"
-    - port: 8012
+    - name: "8012"
+      port: 8012
       targetPort: 8012
-      name: "8012"
-    - port: 8014
+    - name: "8014"
+      port: 8014
       targetPort: 8014
-      name: "8014"
-    - port: 8023
+    - name: "8023"
+      port: 8023
       targetPort: 8023
-      name: "8023"
-    - port: 8021
+    - name: "8021"
+      port: 8021
       targetPort: 8021
-      name: "8021"
-    - port: 8024
+    - name: "8024"
+      port: 8024
       targetPort: 8024
-      name: "8024"
-    - port: 8032
+    - name: "8032"
+      port: 8032
       targetPort: 8032
-      name: "8032"
-    - port: 8031
+    - name: "8031"
+      port: 8031
       targetPort: 8031
-      name: "8031"
-    - port: 8034
+    - name: "8034"
+      port: 8034
       targetPort: 8034
-      name: "8034"
-    - port: 8043
+    - name: "8043"
+      port: 8043
       targetPort: 8043
-      name: "8043"
-    - port: 8041
+    - name: "8041"
+      port: 8041
       targetPort: 8041
-      name: "8041"
-    - port: 8042
+    - name: "8042"
+      port: 8042
       targetPort: 8042
-      name: "8042"
 
 ---
 # -------------------------------
@@ -138,7 +167,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v7.5
+          image: dnagard/kv_store:v7.11
           imagePullPolicy: Always
           env:
             - name: NODES
@@ -158,8 +187,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-              "export PID=$(echo $POD_NAME | sed 's/[^0-9]*\\([0-9]*\\)$/\\1/')&& PID=$((PID + 1))
-              && exec kv_demo",
+              "export PID=$(echo $POD_NAME | sed 's/[^0-9]*\\([0-9]*\\)$/\\1/') && PID=$((PID + 1)) && exec kv_demo",
             ]
           volumeMounts:
             - name: data

--- a/kube.yml
+++ b/kube.yml
@@ -35,7 +35,7 @@ kind: ConfigMap
 metadata:
   name: kv-config
 data:
-  NODES: "[1, 2, 3, 4]"
+  NODES: "[1, 2, 3, 4, 5]"
   RUST_BACKTRACE: "1"
 
 ---
@@ -74,6 +74,9 @@ spec:
     - name: "8014"
       port: 8014
       targetPort: 8014
+    - name: "8015"
+      port: 8015
+      targetPort: 8015
     - name: "8023"
       port: 8023
       targetPort: 8023
@@ -83,6 +86,9 @@ spec:
     - name: "8024"
       port: 8024
       targetPort: 8024
+    - name: "8025"
+      port: 8025
+      targetPort: 8025
     - name: "8032"
       port: 8032
       targetPort: 8032
@@ -92,6 +98,9 @@ spec:
     - name: "8034"
       port: 8034
       targetPort: 8034
+    - name: "8035"
+      port: 8035
+      targetPort: 8035
     - name: "8043"
       port: 8043
       targetPort: 8043
@@ -101,6 +110,21 @@ spec:
     - name: "8042"
       port: 8042
       targetPort: 8042
+    - name: "8045"
+      port: 8045
+      targetPort: 8045
+    - name: "8051"
+      port: 8051
+      targetPort: 8051  
+    - name: "8052"
+      port: 8052
+      targetPort: 8052
+    - name: "8053"
+      port: 8053
+      targetPort: 8053
+    - name: "8054"
+      port: 8054
+      targetPort: 8054
 
 ---
 # -------------------------------
@@ -115,7 +139,7 @@ metadata:
 spec:
   containers:
     - name: net
-      image: dnagard/net_actor:v2.0
+      image: dnagard/net_actor:latest
       imagePullPolicy: Always
       stdin: true
       tty: true
@@ -124,17 +148,31 @@ spec:
         - containerPort: 8002
         - containerPort: 8003
         - containerPort: 8004
+        - containerPort: 8015
+        - containerPort: 8014
         - containerPort: 8013
         - containerPort: 8012
+        - containerPort: 8025
+        - containerPort: 8024
         - containerPort: 8023
         - containerPort: 8021
+        - containerPort: 8035
+        - containerPort: 8034
         - containerPort: 8032
         - containerPort: 8031
+        - containerPort: 8045
+        - containerPort: 8043
+        - containerPort: 8042
+        - containerPort: 8041
+        - containerPort: 8054
+        - containerPort: 8053
+        - containerPort: 8052
+        - containerPort: 8051
       env:
         - name: PORT_MAPPINGS
-          value: "[[8013,8031],[8012,8021],[8023,8032], [8014, 8041], [8024, 8042], [8034, 8043]]"
+          value: "[[8012,8021],[8013,8031],[8014, 8041],[8015, 8051],[8023,8032],[8024, 8042],[8025, 8052],[8034, 8043],[8035, 8053],[8045, 8054]]"
         - name: CLIENT_PORTS
-          value: "[8001, 8002, 8003, 8004]"
+          value: "[8001, 8002, 8003, 8004, 8005]"
         - name: NODES
           valueFrom:
             configMapKeyRef:
@@ -167,7 +205,7 @@ spec:
     spec:
       containers:
         - name: kv-store
-          image: dnagard/kv_store:v7.11
+          image: dnagard/kv_store:pStoreRec
           imagePullPolicy: Always
           env:
             - name: NODES

--- a/kv_store/Cargo.toml
+++ b/kv_store/Cargo.toml
@@ -13,3 +13,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 lazy_static = "1.4"
 rocksdb = "0.21.0"
+k8s-openapi =  { version = "0.24.0", features = ["v1_32"] }
+kube = { version = "0.99.0", features = ["runtime", "derive"] }
+anyhow = "1.0"

--- a/kv_store/Dockerfile
+++ b/kv_store/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70 AS builder
+FROM rust:1.81 AS builder
 WORKDIR /usr/src/kv_demo
 
 RUN set -eux; \
@@ -18,6 +18,6 @@ RUN rm ./src/*.rs ./target/release/deps/kv_demo*
 COPY . .
 RUN cargo install --path .
 
-FROM debian:bullseye-slim
+FROM debian:bookworm AS runtime
 COPY --from=builder /usr/local/cargo/bin/kv_demo /usr/local/bin/kv_demo
 CMD ["kv_demo"]

--- a/kv_store/src/database.rs
+++ b/kv_store/src/database.rs
@@ -1,11 +1,67 @@
 use crate::kv::{KVCommand, KeyValue, KVSnapshot};
-use rocksdb::{Options, DB};
+use rocksdb::{Options, DB, IteratorMode};
+use std::{
+    error::Error,
+    collections::HashMap,
+};
 
 pub struct Database {
     rocks_db: DB,
 }
 
 impl Database {
+    
+    pub fn get_all_key_values(&self) -> Result<Vec<(String, String)>, Box<dyn Error>> {
+        let mut kv_list = Vec::new();
+        // Create an iterator starting at the beginning of the RocksDB instance.
+        let iter = self.rocks_db.iterator(IteratorMode::Start);
+        
+        for result in iter {
+            match result {
+                Ok((key, value)) => {
+                    // Convert key and value from Vec<u8> to String.
+                    let key_str = String::from_utf8(key.to_vec())?;
+                    let value_str = String::from_utf8(value.to_vec())?;
+                    kv_list.push((key_str, value_str));
+                },
+                Err(e) => {
+                    // Optionally handle or log the error.
+                    eprintln!("Error reading key-value pair: {:?}", e);
+                }
+            }
+        }
+        Ok(kv_list)
+    }
+
+    pub fn handle_kv(&self, kv_list: Vec<(String, String)>) {
+        // Build a HashMap from the new state for quick lookup.
+        let new_state: HashMap<String, String> = kv_list.into_iter().collect();
+
+        // Update/insert all key-value pairs from the new state.
+        for (key, value) in new_state.iter() {
+            self.put(key, value);
+        }
+
+        // Iterate over all current keys in the destination database.
+        let current_keys: Vec<String> = self
+            .rocks_db
+            .iterator(IteratorMode::Start)
+            .filter_map(|result| {
+                match result {
+                    Ok((key, _)) => Some(String::from_utf8(key.to_vec()).ok()).flatten(),
+                    Err(_) => None, // Handle errors as needed
+                }
+            })
+            .collect();
+
+        // Delete any key that is in the destination but not in the new state.
+        for key in current_keys {
+            if !new_state.contains_key(&key) {
+                self.delete(&key);
+            }
+        }
+    }
+
     pub fn new(path: &str) -> Self {
         let mut opts = Options::default();
         opts.create_if_missing(true);
@@ -14,7 +70,8 @@ impl Database {
     }
 
     pub fn handle_snapshot(&self, snapshot: KVSnapshot) {
-        println!("Handling snapshot {:?}", snapshot);
+        //DEBUG MESSAGE:
+        //println!("Handling snapshot {:?}", snapshot);
         for (key, value) in snapshot.snapshotted {
             self.put(&key, &value);
         }

--- a/kv_store/src/database.rs
+++ b/kv_store/src/database.rs
@@ -14,7 +14,7 @@ impl Database {
     }
 
     pub fn handle_snapshot(&self, snapshot: KVSnapshot) {
-        println!("Handling snapshot");
+        println!("Handling snapshot {:?}", snapshot);
         for (key, value) in snapshot.snapshotted {
             self.put(&key, &value);
         }

--- a/kv_store/src/kubernetes.rs
+++ b/kv_store/src/kubernetes.rs
@@ -1,0 +1,20 @@
+use kube::{Client, Api};
+use k8s_openapi::api::apps::v1::StatefulSet;
+use anyhow::Result;
+
+pub async fn query_statefulset_replicas() -> Result<u64> {
+    // Create a Kubernetes client
+    let client = Client::try_default().await?;
+    // Create an API handle for StatefulSets in the "default" namespace.
+    let statefulsets: Api<StatefulSet> = Api::namespaced(client, "default");
+    // Get the StatefulSet named "kv-store"
+    let ss = statefulsets.get("kv-store").await?;
+    // Retrieve the desired replica count from the spec; default to 0 if not present.
+    let replicas: u64 = ss.spec
+        .as_ref()
+        .and_then(|spec| spec.replicas) // spec.replicas is an Option<i32>
+        .map(|r| r as u64)
+        .unwrap_or(0);
+    
+    Ok(replicas)
+}

--- a/kv_store/src/kv.rs
+++ b/kv_store/src/kv.rs
@@ -33,12 +33,14 @@ impl Snapshot<KVCommand> for KVSnapshot {
             match e {
                 KVCommand::Put(KeyValue { key, value }) => {
                     snapshotted.insert(key.clone(), value.clone());
-                    println!("Put key: {}, value: {}", key, value);
+                    //DEBUG MESSAGE:
+                    //println!("Put key: {}, value: {}", key, value);
                 }
                 KVCommand::Delete(key) => {
                     if snapshotted.remove(key).is_none() {
                         // key was not in the snapshot
-                        println!("Not in snapshot key: {}", key);
+                        //DEBUG MESSAGE:
+                        //println!("Not in snapshot key: {}", key);
                         deleted_keys.push(key.clone());
                     }
                     deleted_keys.push(key.clone());
@@ -48,8 +50,9 @@ impl Snapshot<KVCommand> for KVSnapshot {
         }
         // remove keys that were put back
         deleted_keys.retain(|k| !snapshotted.contains_key(k));
-        println!("Deleted keys: {:?}", deleted_keys);
-        println!("Snapshotted: {:?}", snapshotted);
+        //DEBUG MESSAGE:
+        // println!("Deleted keys: {:?}", deleted_keys);
+        // println!("Snapshotted: {:?}", snapshotted);
 
         Self {
             snapshotted,
@@ -58,11 +61,12 @@ impl Snapshot<KVCommand> for KVSnapshot {
     }
 
     fn merge(&mut self, delta: Self) {
-        println!("Merging snapshot");
-        println!("Delta snapshot: {:?}", delta.snapshotted);
-        println!("Delta deleted keys: {:?}", delta.deleted_keys);
-        println!("Current snapshot: {:?}", self.snapshotted);
-        println!("Current deleted keys: {:?}", self.deleted_keys);
+        //DEBUG MESSAGE:
+        // println!("Merging snapshot");
+        // println!("Delta snapshot: {:?}", delta.snapshotted);
+        // println!("Delta deleted keys: {:?}", delta.deleted_keys);
+        // println!("Current snapshot: {:?}", self.snapshotted);
+        // println!("Current deleted keys: {:?}", self.deleted_keys);
         for (k, v) in delta.snapshotted {
             self.snapshotted.insert(k, v);
         }

--- a/kv_store/src/network.rs
+++ b/kv_store/src/network.rs
@@ -10,7 +10,7 @@ use tokio::{
     sync::Mutex,
 };
 
-use crate::{kv::KVCommand, server::APIResponse, NODES, PID as MY_PID};
+use crate::{kv::KVCommand, kv::KVSnapshot, server::APIResponse, NODES, PID as MY_PID};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum Message {
@@ -18,6 +18,7 @@ pub(crate) enum Message {
     APIRequest(KVCommand),
     APIResponse(APIResponse),
     Debug(String),
+    StateCatchup(KVSnapshot),
     Reconnect(u64),
 }
 

--- a/kv_store/src/network.rs
+++ b/kv_store/src/network.rs
@@ -10,7 +10,7 @@ use tokio::{
     sync::Mutex,
 };
 
-use crate::{kv::KVCommand, kv::KVSnapshot, server::APIResponse, NODES, PID as MY_PID};
+use crate::{kv::KVCommand, server::APIResponse, NODES, PID as MY_PID};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum Message {
@@ -18,7 +18,7 @@ pub(crate) enum Message {
     APIRequest(KVCommand),
     APIResponse(APIResponse),
     Debug(String),
-    StateCatchup(KVSnapshot),
+    StateCatchup(Vec<(String, String)>),
     Reconnect(u64),
 }
 

--- a/kv_store/src/server.rs
+++ b/kv_store/src/server.rs
@@ -63,7 +63,13 @@ impl Server {
                     self.omni_paxos.handle_incoming(msg);
                 }, 
                 Message::Debug(msg) => {
-                    //println!("Debug: {}", msg);
+                    if(self.omni_paxos.get_current_leader().map(|(id, _)| id) == Some(*MY_PID)){
+                        //Check if there are more nodes in the cluster than there should be. Maybe hash map with a timeout in for each node in case we scale down? Need to set the timeout quite long in case a node crashes.
+                        //If there are more nodes than in the config, we need to trigger reconnection. can trigger reconnection up to 4 instantly, but timeout on the downwards. 
+                        // TODO: Also need to handle the stopsign message in the other nodes. 
+                        // TODO: Also, need to modify the nodes in the config so that 4 isn't included from the start. But still want the net to listen dynamically for new nodes. 
+                    }
+                    println!("Debug: {}", msg);
                 },
                 Message::Reconnect(pid) => {
                     if self.omni_paxos.get_current_leader().map(|(id, _)| id) != Some(*MY_PID) {

--- a/network_actor/src/network.rs
+++ b/network_actor/src/network.rs
@@ -293,6 +293,7 @@ pub async fn run() {
                 map.get(&to_port).cloned() // Cloning outside of lock
             };
 
+            //TODO: May need to add some asyncrhony here to allow messages to be sent even if a node is down. Otherwise a down node will lock the whole system.
             if let Some(sender) = sender {
                 let _ = sender.send(msg);
                 break;


### PR DESCRIPTION
Works for scaling upwards only. Dynamically checks the number of pods configured in the stateful set. If it detects an increase in the configuration, it triggers the reconfigure functionality in OmniPaxos and catches other servers up with its state. 

Also added two multi-platform builds that run this version. They are denoted right now as `net_actor:latest` (as this one will not change much, and can be used for multiple implementations of kv_store), and `kv_store:pStoreRec`. This is the image that implements both persistent storage and reconfiguration. 